### PR TITLE
Allow newly inflated Suspense content to commit as suspended in async batch

### DIFF
--- a/doc/schedule_algorithm.md
+++ b/doc/schedule_algorithm.md
@@ -330,5 +330,5 @@ Secondary spawn process must be used while holding the global lock. Since it use
 
 
 # Problem
-https://react.dev/reference/react/Suspense
+https://react.dev/reference/react/Suspense#preventing-already-revealed-content-from-hiding
 > A transition doesn’t wait for all content to load. It only waits long enough to avoid hiding already revealed content. For example, the website Layout was already revealed, so it would be bad to hide it behind a loading spinner. However, the nested Suspense boundary around Albums is new, so the transition doesn’t wait for it.

--- a/doc/todo.md
+++ b/doc/todo.md
@@ -1,6 +1,5 @@
 - Use task-local storage to pass environmental variables such as is_self_sync to enforce certain invariants during debugging.
 - ~~NOW: Async suspense~~
-    - Allow suspended async under inflated-suspense to commit
     - Async reconcile has_mailbox_update optimization
 - Layout intrinsics
 - Pointer add/remove

--- a/epgi-core/src/async/build/rebuild.rs
+++ b/epgi-core/src/async/build/rebuild.rs
@@ -1,9 +1,9 @@
 use crate::{
     foundation::{Arc, Asc, Container, ContainerOf, InlinableDwsizeVec, Protocol, Provide},
     scheduler::get_current_scheduler,
-    sync::CommitBarrier,
+    sync::{CommitBarrier, ImplCommitRenderObject},
     tree::{
-        ArcChildElementNode, AsyncOutput, BuildContext, BuildResults, BuildSuspendResults,
+        ArcChildElementNode, AsyncOutput, BuildContext, BuildResults, BuildSuspendResults, Element,
         ElementNode, ElementReconcileItem, ElementWidgetPair, FullElement, HookContext,
         HookContextMode, HooksWithEffects, WorkContext, WorkHandle,
     },
@@ -126,6 +126,7 @@ impl<E: FullElement> ElementNode<E> {
                                         child_work_context,
                                         child_handle,
                                         barrier,
+                                        <E as Element>::Impl::ALLOW_ASYNC_COMMIT_INFLATE_SUSPENDED_CHILD,
                                     )
                                 });
                                 // nodes_inflating.push(node.clone());
@@ -146,8 +147,8 @@ impl<E: FullElement> ElementNode<E> {
             }
             Err((children, err)) => {
                 // This is a rebuild. As a result, in the current design, we will always wait until the suspended node is resolved.
-                // When we do commit, the node is guaranteed to be resolved. By then, we have already visited and finished building the new children. 
-                // Therefore, we do not need to visit the mainline children. 
+                // When we do commit, the node is guaranteed to be resolved. By then, we have already visited and finished building the new children.
+                // Therefore, we do not need to visit the mainline children.
                 // Note, this is different from the sync rebuild, which does need to visit the mainline children.
                 drop(children);
                 AsyncOutput::Suspended {

--- a/epgi-core/src/sync/build/commit_render_object.rs
+++ b/epgi-core/src/sync/build/commit_render_object.rs
@@ -121,4 +121,14 @@ pub trait ImplCommitRenderObject<E: Element<Impl = Self>>: ImplElementNode<E> {
 
     // Detach render object if any
     fn detach_render_object(render_object: &Self::OptionArcRenderObject);
+
+    /// In async batches, whether to wait or to commit immediately if the child suspends during inflating.
+    ///
+    /// This mainly determines how [`Suspense`] works together with `startTransition` or generally any async batch.
+    /// And it's highly recommended to only set this for a [`Suspense`]-like component because this is a highly improvised parameter tailored for [`Suspense`].
+    ///
+    /// In React's design, `startTransition` can decide to not wait for a content to resolve, if the suspend happens during the contenxt's initial inflating **and** the [`Suspense`] catching it does not have any remaining exisiting content (thus safe to show a fallback). See: https://react.dev/reference/react/Suspense#preventing-already-revealed-content-from-hiding
+    ///
+    /// If set to true, then in an async batch, any descendant suspended work won't generate a `CommitBarrier` and thus won't prevent the batch from being committed.
+    const ALLOW_ASYNC_COMMIT_INFLATE_SUSPENDED_CHILD: bool = false;
 }

--- a/epgi-core/src/sync/build/commit_render_object/suspense_element.rs
+++ b/epgi-core/src/sync/build/commit_render_object/suspense_element.rs
@@ -294,6 +294,8 @@ impl<P: Protocol> ImplCommitRenderObject<SuspenseElement<P>> for ElementImpl<tru
             .as_ref()
             .map(|render_object| render_object.detach_render_object());
     }
+
+    const ALLOW_ASYNC_COMMIT_INFLATE_SUSPENDED_CHILD: bool = true;
 }
 
 fn inflate_fallback<P: Protocol>(

--- a/epgi-core/src/sync/build/rebuild.rs
+++ b/epgi-core/src/sync/build/rebuild.rs
@@ -151,7 +151,7 @@ impl<E: FullElement> ElementNode<E> {
                 );
 
                 // We need to visit the mainline children instead.
-                // There could be sync updates in the descendants. 
+                // There could be sync updates in the descendants.
                 // If we do not visit and clear them in the current sync visit, the next sync visit will meet
                 // a bunch of undocumented and expired sync updates. State corruption guaranteed.
                 // Note, this is different from the async rebuild, which does not need to visit the mainline children.

--- a/epgi-core/src/tree/element/async_queue.rs
+++ b/epgi-core/src/tree/element/async_queue.rs
@@ -87,6 +87,10 @@ where
         });
     }
 
+    pub(crate) fn backqueue_ref(&self) -> Option<&Vec<AsyncQueueBackqueueEntry<E::ArcWidget>>> {
+        self.inner.as_ref().map(|inner| &inner.backqueue)
+    }
+
     pub(crate) fn backqueue_mut(
         &mut self,
     ) -> Option<&mut Vec<AsyncQueueBackqueueEntry<E::ArcWidget>>> {

--- a/epgi-core/src/tree/element/snapshot.rs
+++ b/epgi-core/src/tree/element/snapshot.rs
@@ -3,7 +3,9 @@ use crate::{
     tree::{AsyncInflating, HooksWithCleanups},
 };
 
-use super::{ArcChildElementNode, ArcSuspendWaker, AsyncWorkQueue, Element, ImplElementNode};
+use super::{
+    ArcChildElementNode, ArcSuspendWaker, AsyncWorkQueue, Element, ImplElementNode, SuspendWaker,
+};
 
 pub(crate) struct ElementSnapshot<E: Element> {
     pub(crate) widget: E::ArcWidget,
@@ -168,11 +170,11 @@ impl<E: Element, H> MainlineState<E, H> {
     //     }
     // }
 
-    // pub(crate) fn waker_ref(&self) -> Option<&SuspendWaker> {
-    //     match self {
-    //         MainlineState::Ready { .. } => None,
-    //         MainlineState::InflateSuspended { waker, .. }
-    //         | MainlineState::RebuildSuspended { waker, .. } => Some(waker),
-    //     }
-    // }
+    pub(crate) fn waker_ref(&self) -> Option<&SuspendWaker> {
+        match self {
+            MainlineState::Ready { .. } => None,
+            MainlineState::InflateSuspended { waker, .. }
+            | MainlineState::RebuildSuspended { waker, .. } => Some(waker),
+        }
+    }
 }

--- a/epgi-core/src/tree/element/waker.rs
+++ b/epgi-core/src/tree/element/waker.rs
@@ -46,6 +46,12 @@ impl ArcWake for SuspendWaker {
 
 impl SuspendWaker {}
 
+impl Drop for SuspendWaker {
+    fn drop(&mut self) {
+        println!("Drop waker")
+    }
+}
+
 impl SuspendWaker {
     // pub(crate) fn new_sync(node: AweakElementContextNode) -> std::sync::Arc<Self> {
     //     std::sync::Arc::new(Self {

--- a/epgi-core/src/tree/hook.rs
+++ b/epgi-core/src/tree/hook.rs
@@ -41,7 +41,7 @@ impl HooksWithEffects {
                 .into_iter()
                 .map(|(hook_state, effect)| {
                     (
-                        hook_state.clone(),
+                        hook_state, // WARNING: NEVER clone here. Clone a state loses all subscribed wakers registered to the old future in the state
                         effect.and_then(|effect| effect.fire_box()),
                     )
                 })


### PR DESCRIPTION
Previous async batch commit is a stopgap impl. It always waits for all contents to resolve before commit.

Now we strictly follows the design in React https://react.dev/reference/react/Suspense#preventing-already-revealed-content-from-hiding. If Suspense content is being inflated, then its content is allowed to commit as suspended in an async batch (i.e. `startTransition`). The demo app's behavior changed as a result.

Fixes:
1. Async batch commit now strictly follows sync batch's order of firing side effects.
2. Fix a bug where committing `FutureHooks` loses subscribed waker. Previous stopgap impl won't encounter this scenario hence undetected.
3. Previously async batch commit forgot to requeue other blocked async work.
